### PR TITLE
Add estimathon-scoreboard deployment manifests

### DIFF
--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -1,7 +1,7 @@
 { ... }:
 
 {
-  namespaces.bmt-estimathon-scoreboard.resources = {
+  namespaces.bmt.resources = {
     "postgresql.cnpg.io/v1".Cluster.estimathon-scoreboard-postgres.spec = {
       instances = 3;
       bootstrap.initdb.database = "estimathon";

--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -23,7 +23,7 @@
               DATABASE_URL.value = "postgres://$(DB_USER):$(DB_PASS)@estimathon-scoreboard-postgres-rw:5432/estimathon";
               HOST.value = "0.0.0.0";
               PORT.value = "8080";
-              BUILD_PATH.value = "./dist";
+              STATIC_DIR.value = "./dist";
               RUST_LOG.value = "info";
             };
             envFrom = [{ secretRef.name = "estimathon-scoreboard"; }];

--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -31,11 +31,6 @@
       };
     };
 
-    v1.Secret.ghcr-auth = {
-      type = "kubernetes.io/dockerconfigjson";
-      stringData.".dockerconfigjson" = "";
-    };
-
     v1.Service.estimathon-scoreboard.spec = {
       selector.app = "estimathon-scoreboard";
       ports = [{

--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -18,9 +18,7 @@
             image = "ghcr.io/berkeleymt/estimathon-scoreboard:latest";
             ports = [{ containerPort = 8080; }];
             env = {
-              DB_USER.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "username"; };
-              DB_PASS.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "password"; };
-              DATABASE_URL.value = "postgres://$(DB_USER):$(DB_PASS)@estimathon-scoreboard-postgres-rw:5432/estimathon";
+              DATABASE_URL.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "uri"; };
               HOST.value = "0.0.0.0";
               PORT.value = "8080";
               STATIC_DIR.value = "./dist";

--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -19,7 +19,6 @@
             ports = [{ containerPort = 8080; }];
             env = {
               DATABASE_URL.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "uri"; };
-              RUST_LOG.value = "info";
             };
             envFrom = [{ secretRef.name = "estimathon-scoreboard"; }];
             resources = {

--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -19,9 +19,6 @@
             ports = [{ containerPort = 8080; }];
             env = {
               DATABASE_URL.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "uri"; };
-              HOST.value = "0.0.0.0";
-              PORT.value = "8080";
-              STATIC_DIR.value = "./dist";
               RUST_LOG.value = "info";
             };
             envFrom = [{ secretRef.name = "estimathon-scoreboard"; }];

--- a/kubernetes/bmt/estimathon-scoreboard.nix
+++ b/kubernetes/bmt/estimathon-scoreboard.nix
@@ -1,0 +1,75 @@
+{ ... }:
+
+{
+  namespaces.bmt-estimathon-scoreboard.resources = {
+    "postgresql.cnpg.io/v1".Cluster.estimathon-scoreboard-postgres.spec = {
+      instances = 3;
+      bootstrap.initdb.database = "estimathon";
+      storage.size = "8Gi";
+    };
+
+    "apps/v1".Deployment.estimathon-scoreboard.spec = {
+      replicas = 1;
+      selector.matchLabels.app = "estimathon-scoreboard";
+      template = {
+        metadata.labels.app = "estimathon-scoreboard";
+        spec = {
+          containers.estimathon-scoreboard = {
+            image = "ghcr.io/berkeleymt/estimathon-scoreboard:latest";
+            ports = [{ containerPort = 8080; }];
+            env = {
+              DB_USER.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "username"; };
+              DB_PASS.valueFrom.secretKeyRef = { name = "estimathon-scoreboard-postgres-app"; key = "password"; };
+              DATABASE_URL.value = "postgres://$(DB_USER):$(DB_PASS)@estimathon-scoreboard-postgres-rw:5432/estimathon";
+              HOST.value = "0.0.0.0";
+              PORT.value = "8080";
+              BUILD_PATH.value = "./dist";
+              RUST_LOG.value = "info";
+            };
+            envFrom = [{ secretRef.name = "estimathon-scoreboard"; }];
+            resources = {
+              limits = { memory = "512Mi"; };
+              requests = { cpu = "100m"; memory = "64Mi"; };
+            };
+          };
+          imagePullSecrets = [{ name = "ghcr-auth"; }];
+        };
+      };
+    };
+
+    v1.Secret.ghcr-auth = {
+      type = "kubernetes.io/dockerconfigjson";
+      stringData.".dockerconfigjson" = "";
+    };
+
+    v1.Service.estimathon-scoreboard.spec = {
+      selector.app = "estimathon-scoreboard";
+      ports = [{
+        port = 80;
+        targetPort = 8080;
+      }];
+    };
+
+    v1.Secret.estimathon-scoreboard.stringData = {
+      JWT_SECRET = "";
+    };
+
+    "networking.k8s.io/v1".Ingress.estimathon-scoreboard-ingress = {
+      metadata.annotations."cert-manager.io/cluster-issuer" = "letsencrypt";
+      spec = {
+        rules = [{
+          host = "estimathon.berkeley.mt";
+          http.paths = [{
+            path = "/";
+            pathType = "Prefix";
+            backend.service = { name = "estimathon-scoreboard"; port.number = 80; };
+          }];
+        }];
+        tls = [{
+          hosts = [ "estimathon.berkeley.mt" ];
+          secretName = "estimathon-scoreboard-ingress-tls";
+        }];
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Adds Kubernetes deployment manifests for the estimathon-scoreboard application, following the same transpire/Nix pattern as other BMT services (guts-scoreboard, discord-bot, stickers).

Includes:
- **CNPG PostgreSQL cluster** (3 instances, 8Gi storage, `estimathon` database)
- **Deployment** pulling `ghcr.io/berkeleymt/estimathon-scoreboard:latest` with DB credentials from CNPG secret
- **Service** (port 80 → 8080)
- **Ingress** at `estimathon.berkeley.mt` with Let's Encrypt TLS
- **Secrets** for `JWT_SECRET` (via Vault) and GHCR auth

Companion PR for the Dockerfile/CI: https://github.com/berkeleymt/estimathon-scoreboard/pull/4

## Review & Testing Checklist for Human

- [ ] Confirm `estimathon.berkeley.mt` is the desired hostname for the ingress
- [ ] Verify the `JWT_SECRET` is pushed to Vault at `hfym-ds/bmt-estimathon-scoreboard/estimathon-scoreboard`
- [ ] Ensure GHCR auth secret is configured for the `bmt-estimathon-scoreboard` namespace
- [ ] After deploying, verify the CNPG cluster bootstraps and the migration runs (the app expects tables from `001_initial.sql`)

### Notes

- The app runs migrations via SQL files (not sqlx migrate), so you may need to run `psql` manually against the CNPG cluster on first deploy
- Resource limits are conservative (512Mi memory, 100m CPU requests) — adjust based on expected load